### PR TITLE
fix: don't apply toString() to json

### DIFF
--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -1,4 +1,4 @@
-import 'constants.dart';
+import 'package:realtime_client/src/constants.dart';
 
 class Message {
   String topic;

--- a/lib/src/push.dart
+++ b/lib/src/push.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
-import 'constants.dart';
-import 'message.dart';
-import 'realtime_subscription.dart';
+import 'package:realtime_client/src/constants.dart';
+import 'package:realtime_client/src/message.dart';
+import 'package:realtime_client/src/realtime_subscription.dart';
 
 typedef Callback = void Function(dynamic response);
 

--- a/lib/src/realtime_client.dart
+++ b/lib/src/realtime_client.dart
@@ -2,15 +2,14 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:core';
 
-import 'package:web_socket_channel/web_socket_channel.dart';
-
-import 'constants.dart';
-import 'message.dart';
-import 'realtime_subscription.dart';
-import 'retry_timer.dart';
-import 'websocket_stub.dart'
+import 'package:realtime_client/src/constants.dart';
+import 'package:realtime_client/src/message.dart';
+import 'package:realtime_client/src/realtime_subscription.dart';
+import 'package:realtime_client/src/retry_timer.dart';
+import 'package:realtime_client/src/websocket_stub.dart'
     if (dart.library.io) 'websocket_io.dart'
     if (dart.library.html) 'websocket_web.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
 
 class RealtimeClient {
   List<RealtimeSubscription> channels = [];

--- a/lib/src/realtime_subscription.dart
+++ b/lib/src/realtime_subscription.dart
@@ -1,7 +1,7 @@
-import 'constants.dart';
-import 'push.dart';
-import 'realtime_client.dart';
-import 'retry_timer.dart';
+import 'package:realtime_client/src/constants.dart';
+import 'package:realtime_client/src/push.dart';
+import 'package:realtime_client/src/realtime_client.dart';
+import 'package:realtime_client/src/retry_timer.dart';
 
 class Binding {
   String event;

--- a/lib/src/transformers.dart
+++ b/lib/src/transformers.dart
@@ -2,6 +2,7 @@
 // 3-clause BSD found here: https://raw.githubusercontent.com/epgsql/epgsql/devel/LICENSE
 
 import 'dart:convert';
+
 import 'package:collection/collection.dart' show IterableExtension;
 
 enum PostgresTypes {
@@ -107,16 +108,11 @@ dynamic convertColumn(
 ) {
   final column = columns.firstWhereOrNull((x) => x.name == columnName);
   final columnValue = record[columnName];
-  final columnValueStr = columnValue == null
-      ? null
-      : columnValue is String
-          ? columnValue
-          : columnValue.toString();
 
   if (column != null && !skipTypes.contains(column.type)) {
-    return convertCell(column.type, columnValueStr);
+    return convertCell(column.type, columnValue);
   }
-  return noop(columnValueStr);
+  return noop(columnValue);
 }
 
 /// If the value of the cell is `null`, returns null.


### PR DESCRIPTION
Currently, each column value is turned to `String` via `.toString()`, but when this gets applied to a `Map`/`json` the corresponding string isn't a valid string presentation of the map. So decoding it again with `json.decode()` fails. I removed the `.toString()` call, because it's either a Map or a String. If it's a bool, it gets recognized as such either way later on in `toBoolean` called in `convertCell()`

I see it got already discussed in #30