### PR TITLE
feat: bring presence and broadcast feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.0.0-dev.1]
+
+- feat: add support for broadcast and presence
+- BREAKING: API change for listening to realtime data
+```dart
+TODO: insert upgrade guide here
+```
+
+
 ## [0.1.15]
 
 - fix: use toString() instead of type cast error response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - feat: add support for broadcast and presence
 - BREAKING: API change for listening to database realtime changes
 ```dart
-final socket = RealtimeClient('');
+final socket = RealtimeClient('ws://SUPABASE_API_ENDPOINT/realtime/v1');
 final channel = socket.channel('can_be_any_string');
 
 // listen to insert events on public.messages table
@@ -48,7 +48,6 @@ channel.subscribe((status) async {
   }
 });
 ```
-
 
 ## [0.1.15]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [1.0.0-dev.1]
 
 - feat: add support for broadcast and presence
-- BREAKING: API change for listening to database realtime changes
+- BREAKING: `.on()` no longer takes a event string (e.g. INSERT, UPDATE or DELETE), but takes `RealtimeListenTypes` and a `ChannelFilter`
 ```dart
 final socket = RealtimeClient('ws://SUPABASE_API_ENDPOINT/realtime/v1');
 final channel = socket.channel('can_be_any_string');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,52 @@
 ## [1.0.0-dev.1]
 
 - feat: add support for broadcast and presence
-- BREAKING: API change for listening to realtime data
+- BREAKING: API change for listening to database realtime changes
 ```dart
-TODO: insert upgrade guide here
+final socket = RealtimeClient('');
+final channel = socket.channel('can_be_any_string');
+
+// listen to insert events on public.messages table
+channel.on(
+    RealtimeListenTypes.postgresChanges,
+    ChannelFilter(
+      event: 'INSERT',
+      schema: 'public',
+      table: 'messages',
+    ), (payload, [ref]) {
+  print('database insert payload: $payload');
+});
+
+// listen to `location` broadcast events
+channel.on(
+    RealtimeListenTypes.broadcast,
+    ChannelFilter(
+      event: 'location',
+    ), (payload, [ref]) {
+  print(payload);
+});
+
+// send `location` broadcast events
+channel.send(
+  type: RealtimeListenTypes.broadcast,
+  event: 'location',
+  payload: {'lat': 1.3521, 'lng': 103.8198},
+);
+
+// listen to presence states
+channel.on(RealtimeListenTypes.presence, ChannelFilter(event: 'sync'),
+    (payload, [ref]) {
+  print(payload);
+  print(channel.presenceState());
+});
+
+// subscribe to the above changes
+channel.subscribe((status) async {
+  if (status == 'SUBSCRIBED') {
+    // if subscribed successfully, send presence event
+    final status = await channel.track({'user_id': myUserId});
+  }
+});
 ```
 
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -10,10 +10,10 @@ Future<void> main() async {
   );
 
   final channel = socket.channel('realtime:public');
-  channel.on('DELETE', (payload, {ref}) {
+  channel.onEvents('DELETE', (payload, {ref}) {
     print('channel delete payload: $payload');
   });
-  channel.on('INSERT', (payload, {ref}) {
+  channel.onEvents('INSERT', (payload, {ref}) {
     print('channel insert payload: $payload');
   });
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -23,7 +23,7 @@ Future<void> main() async {
 
   // on connect and subscribe
   socket.connect();
-  channel.subscribe((a) => print('SUBSCRIBED'));
+  channel.subscribe((a, [_]) => print('SUBSCRIBED'));
 
   // delay 20s to receive events from server
   await Future.delayed(const Duration(seconds: 20));

--- a/example/main.dart
+++ b/example/main.dart
@@ -10,10 +10,12 @@ Future<void> main() async {
   );
 
   final channel = socket.channel('realtime:public');
-  channel.onEvents('DELETE', (payload, {ref}) {
+  channel.on(RealtimeListenTypes.postgresChanges,
+      ChannelFilter(event: 'DELETE', schema: 'public'), (payload, [ref]) {
     print('channel delete payload: $payload');
   });
-  channel.onEvents('INSERT', (payload, {ref}) {
+  channel.on(RealtimeListenTypes.postgresChanges,
+      ChannelFilter(event: 'INSERT', schema: 'public'), (payload, [ref]) {
     print('channel insert payload: $payload');
   });
 
@@ -21,7 +23,7 @@ Future<void> main() async {
 
   // on connect and subscribe
   socket.connect();
-  channel.subscribe().receive('ok', (_) => print('SUBSCRIBED'));
+  channel.subscribe((a) => print('SUBSCRIBED'));
 
   // delay 20s to receive events from server
   await Future.delayed(const Duration(seconds: 20));

--- a/lib/realtime_client.dart
+++ b/lib/realtime_client.dart
@@ -1,3 +1,3 @@
 export 'src/realtime_client.dart';
-export 'src/realtime_subscription.dart';
+export 'src/realtime_channel.dart';
 export 'src/transformers.dart';

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -40,7 +40,7 @@ extension ChannelEventsName on ChannelEvents {
     } else if (this == ChannelEvents.postgresChanges) {
       return 'postgres_changes';
     }
-    return 'phx_${toString().split('.').last}';
+    return 'phx_$name';
   }
 }
 

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -13,12 +13,32 @@ enum SocketStates { connecting, open, closing, closed, disconnected }
 
 enum ChannelStates { closed, errored, joined, joining, leaving }
 
-enum ChannelEvents { close, error, join, reply, leave, heartbeat, accessToken }
+enum ChannelEvents {
+  close,
+  error,
+  join,
+  reply,
+  leave,
+  heartbeat,
+  accessToken,
+  broadcast,
+  presence,
+  postgresChanges;
+
+  static ChannelEvents fromName(String type) {
+    for (ChannelEvents enumVariant in ChannelEvents.values) {
+      if (enumVariant.name == type) return enumVariant;
+    }
+    throw 'No type $type exists';
+  }
+}
 
 extension ChannelEventsName on ChannelEvents {
   String eventName() {
     if (this == ChannelEvents.accessToken) {
       return 'access_token';
+    } else if (this == ChannelEvents.postgresChanges) {
+      return 'postgres_changes';
     }
     return 'phx_${toString().split('.').last}';
   }

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -39,6 +39,10 @@ extension ChannelEventsName on ChannelEvents {
       return 'access_token';
     } else if (this == ChannelEvents.postgresChanges) {
       return 'postgres_changes';
+    } else if (this == ChannelEvents.broadcast) {
+      return 'broadcast';
+    } else if (this == ChannelEvents.presence) {
+      return 'presence';
     }
     return 'phx_$name';
   }

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -5,7 +5,7 @@ class Message {
   String topic;
   ChannelEvents event;
   dynamic payload;
-  String? ref;
+  String ref;
 
   Message({
     required this.topic,
@@ -14,6 +14,7 @@ class Message {
     required this.ref,
   });
 
+  /// Converting to JSON while removing functions
   Map<String, dynamic> toJson() {
     late final dynamic processedPayload;
     if (payload is Map) {
@@ -23,8 +24,8 @@ class Message {
         if (outerValue is Map) {
           for (final innerKey in outerValue.keys) {
             final innerValue = outerValue[innerKey];
+            processedPayload[outerKey] ??= {};
             if (innerValue is Binding) {
-              processedPayload[outerKey] ??= {};
               processedPayload[outerKey][innerKey] = <String, dynamic>{
                 'type': innerValue.type,
                 'filter': innerValue.filter,

--- a/lib/src/push.dart
+++ b/lib/src/push.dart
@@ -87,7 +87,7 @@ class Push {
     _ref = _channel.socket.makeRef();
     _refEvent = _channel.replyEventName(ref);
 
-    _channel.on(_refEvent!, {}, (dynamic payload, [ref]) {
+    _channel.on(_refEvent!, ChannelFilter(), (dynamic payload, [ref]) {
       _cancelRefEvent();
       _cancelTimeout();
       _receivedResp = payload;

--- a/lib/src/push.dart
+++ b/lib/src/push.dart
@@ -2,13 +2,13 @@ import 'dart:async';
 
 import 'package:realtime_client/src/constants.dart';
 import 'package:realtime_client/src/message.dart';
-import 'package:realtime_client/src/realtime_subscription.dart';
+import 'package:realtime_client/src/realtime_channel.dart';
 
 typedef Callback = void Function(dynamic response);
 
 /// Push event obj
 class Push {
-  final RealtimeSubscription _channel;
+  final RealtimeChannel _channel;
   final ChannelEvents _event;
   String? _ref;
   String? _refEvent;
@@ -80,7 +80,7 @@ class Push {
     _ref = _channel.socket.makeRef();
     _refEvent = _channel.replyEventName(ref);
 
-    _channel.on(_refEvent!, (dynamic payload, {ref}) {
+    _channel.on(_refEvent!, {}, (dynamic payload, {ref}) {
       cancelRefEvent();
       cancelTimeout();
       _receivedResp = payload;

--- a/lib/src/push.dart
+++ b/lib/src/push.dart
@@ -87,7 +87,7 @@ class Push {
     _ref = _channel.socket.makeRef();
     _refEvent = _channel.replyEventName(ref);
 
-    _channel.on(_refEvent!, ChannelFilter(), (dynamic payload, [ref]) {
+    _channel.onEvents(_refEvent!, ChannelFilter(), (dynamic payload, [ref]) {
       _cancelRefEvent();
       _cancelTimeout();
       _receivedResp = payload;

--- a/lib/src/push.dart
+++ b/lib/src/push.dart
@@ -127,9 +127,9 @@ class Push {
     String status,
     dynamic response,
   ) {
-    _recHooks
-        .where((h) => h.status == status)
-        .forEach((h) => h.callback(response));
+    _recHooks.where((h) => h.status == status).forEach((h) {
+      h.callback(response);
+    });
   }
 
   bool _hasReceived(String status) {

--- a/lib/src/realtime_channel.dart
+++ b/lib/src/realtime_channel.dart
@@ -370,12 +370,16 @@ class RealtimeChannel {
 
   Future<ChannelResponse> send({
     required RealtimeListenTypes type,
+    String? event,
     required Map<String, dynamic> payload,
     Map<String, dynamic> opts = const {},
   }) {
     final completer = Completer<ChannelResponse>();
 
     payload['type'] = type.toType();
+    if (event != null) {
+      payload['event'] = event;
+    }
 
     final push = this.push(
       ChannelEvents.fromName(payload['type']),

--- a/lib/src/realtime_channel.dart
+++ b/lib/src/realtime_channel.dart
@@ -14,16 +14,16 @@ class Binding {
 }
 
 class RealtimeChannel {
+  List<Binding> _bindings = [];
+  final Duration _timeout;
   ChannelStates _state = ChannelStates.closed;
+  bool joinedOnce = false;
+  late Push _joinPush;
+  late RetryTimer _rejoinTimer;
+  List<Push> _pushBuffer = [];
   final String topic;
   final Map<String, dynamic> params;
   final RealtimeClient socket;
-  late RetryTimer _rejoinTimer;
-  List<Push> _pushBuffer = [];
-  List<Binding> _bindings = [];
-  bool joinedOnce = false;
-  late Push _joinPush;
-  final Duration _timeout;
 
   RealtimeChannel(this.topic, this.socket, {this.params = const {}})
       : _timeout = socket.timeout {

--- a/lib/src/realtime_channel.dart
+++ b/lib/src/realtime_channel.dart
@@ -7,7 +7,7 @@ import 'package:realtime_client/src/push.dart';
 import 'package:realtime_client/src/realtime_presence.dart';
 import 'package:realtime_client/src/retry_timer.dart';
 
-typedef BindingCallback = void Function(dynamic payload, [String? ref]);
+typedef BindingCallback = void Function(dynamic payload, [dynamic ref]);
 
 class Binding {
   String type;
@@ -552,7 +552,7 @@ class RealtimeChannel {
             final bindEvent = bind.filter['event'];
 
             return (bindId != null &&
-                payload['ids']?.contains(bindId) &&
+                (payload['ids'] as List?)?.contains(bindId) == true &&
                 (bindEvent == '*' ||
                     bindEvent?.toLowerCase() ==
                         payload['data']?['type'].toLowerCase()));

--- a/lib/src/realtime_channel.dart
+++ b/lib/src/realtime_channel.dart
@@ -268,7 +268,7 @@ class RealtimeChannel {
         'event': 'track',
         'payload': payload,
       },
-      opts['timeout'] ?? _timeout,
+      {'timeout': opts['timeout'] ?? _timeout},
     );
   }
 

--- a/lib/src/realtime_channel.dart
+++ b/lib/src/realtime_channel.dart
@@ -551,8 +551,7 @@ class RealtimeChannel {
           if (bindId != null) {
             final bindEvent = bind.filter['event'];
 
-            return (bindId != null &&
-                (payload['ids'] as List?)?.contains(int.parse(bindId)) ==
+            return ((payload['ids'] as List?)?.contains(int.parse(bindId)) ==
                     true &&
                 (bindEvent == '*' ||
                     bindEvent?.toLowerCase() ==
@@ -566,7 +565,6 @@ class RealtimeChannel {
           return bind.type.toLowerCase() == typeLower;
         }
       });
-      print(bindings);
       for (final bind in bindings) {
         if (handledPayload is Map && handledPayload.keys.contains('ids')) {
           final postgresChanges = handledPayload['data'];

--- a/lib/src/realtime_channel.dart
+++ b/lib/src/realtime_channel.dart
@@ -91,7 +91,7 @@ enum RealtimeListenTypes {
   }
 }
 
-class ChannelParams {
+class RealtimeChannelConfig {
   /// [ack] option instructs server to acknowlege that broadcast message was received
   final bool ack;
 
@@ -101,7 +101,7 @@ class ChannelParams {
   /// [key] option is used to track presence payload across clients
   final String key;
 
-  const ChannelParams({
+  const RealtimeChannelConfig({
     this.ack = false,
     this.self = false,
     this.key = '',
@@ -137,7 +137,7 @@ class RealtimeChannel {
   final RealtimeClient socket;
 
   RealtimeChannel(this.topic, this.socket,
-      {ChannelParams params = const ChannelParams()})
+      {RealtimeChannelConfig params = const RealtimeChannelConfig()})
       : _timeout = socket.timeout,
         params = params.toMap() {
     joinPush = Push(

--- a/lib/src/realtime_client.dart
+++ b/lib/src/realtime_client.dart
@@ -122,11 +122,7 @@ class RealtimeClient {
       conn!.stream.timeout(Duration(milliseconds: longpollerTimeout));
       conn!.stream.listen(
         // incoming messages
-        (message) {
-          print('receiving message');
-          print(message);
-          onConnMessage(message as String);
-        },
+        (message) => onConnMessage(message as String),
         onError: _onConnError,
         onDone: () {
           // communication has been closed
@@ -252,11 +248,7 @@ class RealtimeClient {
   String? push(Message message) {
     final event = message.event;
     void callback() {
-      encode(message.toJson(), (result) {
-        print('sending data');
-        print(result);
-        conn?.sink.add(result);
-      });
+      encode(message.toJson(), (result) => conn?.sink.add(result));
     }
 
     log('push', '${message.topic} ${message.event} (${message.ref})',

--- a/lib/src/realtime_client.dart
+++ b/lib/src/realtime_client.dart
@@ -29,7 +29,7 @@ class RealtimeClient {
   List<RealtimeChannel> channels = [];
   final String endPoint;
   final Map<String, String> headers;
-  final Map<String, String> params;
+  final Map<String, dynamic> params;
   final Duration timeout;
   final WebSocketTransport transport;
   int heartbeatIntervalMs = 30000;
@@ -249,7 +249,6 @@ class RealtimeClient {
     final event = message.event;
     void callback() {
       encode(message.toJson(), (result) {
-        // print('send message $result');
         conn?.sink.add(result);
       });
     }

--- a/lib/src/realtime_client.dart
+++ b/lib/src/realtime_client.dart
@@ -4,7 +4,7 @@ import 'dart:core';
 
 import 'package:realtime_client/src/constants.dart';
 import 'package:realtime_client/src/message.dart';
-import 'package:realtime_client/src/realtime_subscription.dart';
+import 'package:realtime_client/src/realtime_channel.dart';
 import 'package:realtime_client/src/retry_timer.dart';
 import 'package:realtime_client/src/websocket/websocket.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -26,7 +26,7 @@ typedef RealtimeDecode = void Function(
 
 class RealtimeClient {
   String? accessToken;
-  List<RealtimeSubscription> channels = [];
+  List<RealtimeChannel> channels = [];
   final String endPoint;
   final Map<String, String> headers;
   final Map<String, String> params;
@@ -195,11 +195,11 @@ class RealtimeClient {
   bool get isConnected => connectionState == 'open';
 
   /// Removes a subscription from the socket.
-  void remove(RealtimeSubscription channel) {
+  void remove(RealtimeChannel channel) {
     channels = channels.where((c) => c.joinRef != channel.joinRef).toList();
   }
 
-  RealtimeSubscription channel(
+  RealtimeChannel channel(
     String topic, {
     Map<String, dynamic> chanParams = const {},
   }) {
@@ -208,7 +208,7 @@ class RealtimeClient {
     }
 
     // Check for vsndate. If so, use a [RealtimeChannel] instead
-    final chan = RealtimeSubscription(topic, this, params: chanParams);
+    final chan = RealtimeChannel(topic, this, params: chanParams);
     channels.add(chan);
     return chan;
   }

--- a/lib/src/realtime_client.dart
+++ b/lib/src/realtime_client.dart
@@ -200,9 +200,9 @@ class RealtimeClient {
   }
 
   RealtimeChannel channel(
-    String topic, {
+    String topic, [
     Map<String, dynamic> chanParams = const {},
-  }) {
+  ]) {
     if (chanParams.isNotEmpty && chanParams['selfBroadcast'] != null) {
       params['self_broadcast'] = chanParams['selfBroadcast']!.toString();
     }
@@ -271,8 +271,8 @@ class RealtimeClient {
       channels.where((channel) => channel.isMember(topic)).forEach(
             (channel) => channel.trigger(
               event,
-              payload: payload,
-              ref: ref,
+              payload,
+              ref,
             ),
           );
       for (final callback in stateChangeCallbacks['message']!) {

--- a/lib/src/realtime_client.dart
+++ b/lib/src/realtime_client.dart
@@ -441,7 +441,7 @@ class RealtimeClient {
       topic: 'phoenix',
       event: ChannelEvents.heartbeat,
       payload: {},
-      ref: pendingHeartbeatRef,
+      ref: pendingHeartbeatRef!,
     ));
     setAuth(accessToken);
   }

--- a/lib/src/realtime_client.dart
+++ b/lib/src/realtime_client.dart
@@ -33,17 +33,14 @@ class RealtimeClient {
   final Duration timeout;
   final WebSocketTransport transport;
   int heartbeatIntervalMs = 30000;
-  int longpollerTimeout = 20000;
   Timer? heartbeatTimer;
   String? pendingHeartbeatRef;
   int ref = 0;
   late RetryTimer reconnectTimer;
-
   void Function(String? kind, String? msg, dynamic data)? logger;
   late RealtimeEncode encode;
   late RealtimeDecode decode;
   late TimerCalculation reconnectAfterMs;
-
   WebSocketChannel? conn;
   List sendBuffer = [];
   Map<String, List<Function>> stateChangeCallbacks = {
@@ -52,7 +49,10 @@ class RealtimeClient {
     'error': [],
     'message': []
   };
+  int longpollerTimeout = 20000;
   SocketStates? connState;
+  int eventsPerSecondLimitMs = 100;
+  bool inThrottle = false;
 
   /// Initializes the Socket
   ///
@@ -70,21 +70,26 @@ class RealtimeClient {
   RealtimeClient(
     String endPoint, {
     WebSocketTransport? transport,
-    RealtimeEncode? encode,
-    RealtimeDecode? decode,
     this.timeout = Constants.defaultTimeout,
     this.heartbeatIntervalMs = 30000,
-    this.longpollerTimeout = 20000,
-    TimerCalculation? reconnectAfterMs,
     this.logger,
-    this.params = const {},
+    RealtimeEncode? encode,
+    RealtimeDecode? decode,
+    TimerCalculation? reconnectAfterMs,
     Map<String, String>? headers,
+    this.params = const {},
+    this.longpollerTimeout = 20000,
   })  : endPoint = '$endPoint/${Transports.websocket}',
         headers = {
           ...Constants.defaultHeaders,
           if (headers != null) ...headers,
         },
         transport = transport ?? createWebSocketClient {
+    final eventsPerSecond = params['eventsPerSecond'];
+    if (eventsPerSecond != null) {
+      eventsPerSecondLimitMs = (1000 / int.parse(eventsPerSecond)).floor();
+    }
+
     this.reconnectAfterMs =
         reconnectAfterMs ?? RetryTimer.createRetryFunction();
     this.encode = encode ??
@@ -94,8 +99,8 @@ class RealtimeClient {
         (String payload, Function(dynamic result) callback) =>
             callback(json.decode(payload));
     reconnectTimer = RetryTimer(
-      () async {
-        await disconnect();
+      () {
+        disconnect();
         connect();
       },
       this.reconnectAfterMs,
@@ -104,7 +109,9 @@ class RealtimeClient {
 
   /// Connects the socket.
   void connect() {
-    if (conn != null) return;
+    if (conn != null) {
+      return;
+    }
 
     try {
       connState = SocketStates.connecting;
@@ -132,17 +139,40 @@ class RealtimeClient {
   }
 
   /// Disconnects the socket with status [code] and [reason] for the disconnect
-  Future<void> disconnect({int? code, String? reason}) async {
+  void disconnect({int? code, String? reason}) {
     final conn = this.conn;
     if (conn != null) {
       connState = SocketStates.disconnected;
       if (code != null) {
-        await conn.sink.close(code, reason ?? '');
+        conn.sink.close(code, reason ?? '');
       } else {
-        await conn.sink.close();
+        conn.sink.close();
       }
       this.conn = null;
+
+      // remove open handles
+      if (heartbeatTimer != null) heartbeatTimer?.cancel();
+      reconnectTimer.reset();
     }
+  }
+
+  List<RealtimeChannel> getChannels() {
+    return channels;
+  }
+
+  Future<String> removeChannel(RealtimeChannel channel) async {
+    final status = await channel.unsubscribe();
+    if (channels.isEmpty) {
+      disconnect();
+    }
+    return status;
+  }
+
+  Future<List<String>> removeAllChannels() async {
+    final values =
+        await Future.wait(channels.map((channel) => channel.unsubscribe()));
+    disconnect();
+    return values;
   }
 
   /// Logs the message. Override `this.logger` for specialized logging.
@@ -203,17 +233,20 @@ class RealtimeClient {
     String topic, [
     Map<String, dynamic> chanParams = const {},
   ]) {
-    if (chanParams.isNotEmpty && chanParams['selfBroadcast'] != null) {
-      params['self_broadcast'] = chanParams['selfBroadcast']!.toString();
+    if (!isConnected) {
+      connect();
     }
 
-    // Check for vsndate. If so, use a [RealtimeChannel] instead
-    final chan = RealtimeChannel(topic, this, params: chanParams);
+    final chan = RealtimeChannel('realtime:$topic', this, params: chanParams);
     channels.add(chan);
     return chan;
   }
 
-  void push(Message message) {
+  /// Push out a message if the socket is connected.
+  ///
+  /// If the socket is not connected, the message gets enqueued within a local buffer, and sent out when a connection is next established.
+  String? push(Message message) {
+    final event = message.event;
     void callback() {
       encode(message.toJson(), (result) {
         // print('send message $result');
@@ -221,35 +254,26 @@ class RealtimeClient {
       });
     }
 
-    log(
-      'push',
-      '${message.topic} ${message.event} (${message.ref})',
-      message.payload,
-    );
+    log('push', '${message.topic} ${message.event} (${message.ref})',
+        message.payload);
 
     if (isConnected) {
-      callback();
+      if ([
+        ChannelEvents.broadcast,
+        ChannelEvents.presence,
+        ChannelEvents.postgresChanges
+      ].contains(event)) {
+        final isThrottled = _throttle(callback)();
+        if (isThrottled) {
+          return 'rate limited';
+        }
+      } else {
+        callback();
+      }
     } else {
       sendBuffer.add(callback);
     }
-  }
-
-  /// Returns the URL of the websocket.
-  String get endPointURL {
-    final params = Map<String, String>.from(this.params);
-    params['vsn'] = Constants.vsn;
-    return _appendParams(endPoint, params);
-  }
-
-  /// Return the next message ref, accounting for overflows
-  String makeRef() {
-    final int newRef = ref + 1;
-    if (newRef < 0) {
-      ref = 0;
-    } else {
-      ref = newRef;
-    }
-    return ref.toString();
+    return null;
   }
 
   void onConnMessage(String rawMessage) {
@@ -281,29 +305,22 @@ class RealtimeClient {
     });
   }
 
-  void sendHeartbeat() {
-    if (!isConnected) return;
+  /// Returns the URL of the websocket.
+  String get endPointURL {
+    final params = Map<String, String>.from(this.params);
+    params['vsn'] = Constants.vsn;
+    return _appendParams(endPoint, params);
+  }
 
-    if (pendingHeartbeatRef != null) {
-      pendingHeartbeatRef = null;
-      log(
-        'transport',
-        'heartbeat timeout. Attempting to re-establish connection',
-      );
-      conn?.sink.close(Constants.wsCloseNormal, 'heartbeat timeout');
-      return;
+  /// Return the next message ref, accounting for overflows
+  String makeRef() {
+    final int newRef = ref + 1;
+    if (newRef < 0) {
+      ref = 0;
+    } else {
+      ref = newRef;
     }
-
-    pendingHeartbeatRef = makeRef();
-    push(
-      Message(
-        topic: 'phoenix',
-        event: ChannelEvents.heartbeat,
-        payload: {},
-        ref: pendingHeartbeatRef,
-      ),
-    );
-    setAuth(accessToken);
+    return ref.toString();
   }
 
   /// Sets the JWT access token used for channel subscription authorization and Realtime RLS.
@@ -385,7 +402,9 @@ class RealtimeClient {
   }
 
   String _appendParams(String url, Map<String, String> params) {
-    if (params.keys.isEmpty) return url;
+    if (params.keys.isEmpty) {
+      return url;
+    }
 
     var endpoint = Uri.parse(url);
     final searchParams = Map<String, dynamic>.from(endpoint.queryParameters);
@@ -402,5 +421,41 @@ class RealtimeClient {
       }
       sendBuffer = [];
     }
+  }
+
+  void sendHeartbeat() {
+    if (!isConnected) {
+      return;
+    }
+    if (pendingHeartbeatRef != null) {
+      pendingHeartbeatRef = null;
+      log(
+        'transport',
+        'heartbeat timeout. Attempting to re-establish connection',
+      );
+      conn?.sink.close(Constants.wsCloseNormal, 'heartbeat timeout');
+      return;
+    }
+    pendingHeartbeatRef = makeRef();
+    push(Message(
+      topic: 'phoenix',
+      event: ChannelEvents.heartbeat,
+      payload: {},
+      ref: pendingHeartbeatRef,
+    ));
+    setAuth(accessToken);
+  }
+
+  bool Function() _throttle(Function callback, [int? eventsPerSecondLimit]) {
+    return () {
+      if (inThrottle) return true;
+      callback();
+      inThrottle = true;
+      Timer(
+          Duration(
+              milliseconds: eventsPerSecondLimit ?? eventsPerSecondLimitMs),
+          () => inThrottle = false);
+      return false;
+    };
   }
 }

--- a/lib/src/realtime_client.dart
+++ b/lib/src/realtime_client.dart
@@ -231,7 +231,7 @@ class RealtimeClient {
 
   RealtimeChannel channel(
     String topic, [
-    ChannelParams params = const ChannelParams(),
+    RealtimeChannelConfig params = const RealtimeChannelConfig(),
   ]) {
     if (!isConnected) {
       connect();

--- a/lib/src/realtime_client.dart
+++ b/lib/src/realtime_client.dart
@@ -231,13 +231,13 @@ class RealtimeClient {
 
   RealtimeChannel channel(
     String topic, [
-    Map<String, dynamic> chanParams = const {},
+    Map<String, dynamic>? params,
   ]) {
     if (!isConnected) {
       connect();
     }
 
-    final chan = RealtimeChannel('realtime:$topic', this, params: chanParams);
+    final chan = RealtimeChannel('realtime:$topic', this, params: params);
     channels.add(chan);
     return chan;
   }
@@ -291,13 +291,13 @@ class RealtimeClient {
         payload,
       );
 
-      channels.where((channel) => channel.isMember(topic)).forEach(
-            (channel) => channel.trigger(
-              event,
-              payload,
-              ref,
-            ),
-          );
+      channels
+          .where((channel) => channel.isMember(topic))
+          .forEach((channel) => channel.trigger(
+                event,
+                payload,
+                ref,
+              ));
       for (final callback in stateChangeCallbacks['message']!) {
         callback(msg);
       }

--- a/lib/src/realtime_client.dart
+++ b/lib/src/realtime_client.dart
@@ -122,7 +122,11 @@ class RealtimeClient {
       conn!.stream.timeout(Duration(milliseconds: longpollerTimeout));
       conn!.stream.listen(
         // incoming messages
-        (message) => onConnMessage(message as String),
+        (message) {
+          print('receiving message');
+          print(message);
+          onConnMessage(message as String);
+        },
         onError: _onConnError,
         onDone: () {
           // communication has been closed
@@ -249,6 +253,8 @@ class RealtimeClient {
     final event = message.event;
     void callback() {
       encode(message.toJson(), (result) {
+        print('sending data');
+        print(result);
         conn?.sink.add(result);
       });
     }

--- a/lib/src/realtime_client.dart
+++ b/lib/src/realtime_client.dart
@@ -231,7 +231,7 @@ class RealtimeClient {
 
   RealtimeChannel channel(
     String topic, [
-    Map<String, dynamic>? params,
+    ChannelParams params = const ChannelParams(),
   ]) {
     if (!isConnected) {
       connect();

--- a/lib/src/realtime_presence.dart
+++ b/lib/src/realtime_presence.dart
@@ -58,7 +58,7 @@ class RealtimePresence {
     final events = opts?.events ??
         PresenceEvents(state: 'presence_state', diff: 'presence_diff');
 
-    channel.on(events.state, ChannelFilter(), (newState, [_]) {
+    channel.onEvents(events.state, ChannelFilter(), (newState, [_]) {
       final onJoin = caller['onJoin'];
       final onLeave = caller['onLeave'];
       final onSync = caller['onSync'];
@@ -86,7 +86,7 @@ class RealtimePresence {
       onSync();
     });
 
-    channel.on(events.diff, ChannelFilter(), (diff, [_]) {
+    channel.onEvents(events.diff, ChannelFilter(), (diff, [_]) {
       final onJoin = caller['onJoin'];
       final onLeave = caller['onLeave'];
       final onSync = caller['onSync'];

--- a/lib/src/realtime_presence.dart
+++ b/lib/src/realtime_presence.dart
@@ -91,7 +91,7 @@ class RealtimePresence {
     final events = opts?.events ??
         PresenceEvents(state: 'presence_state', diff: 'presence_diff');
 
-    channel.on(events.state, {}, (newState, {ref}) {
+    channel.on(events.state, {}, (newState, [ref]) {
       final onJoin = caller['onJoin'];
       final onLeave = caller['onLeave'];
       final onSync = caller['onSync'];
@@ -119,7 +119,7 @@ class RealtimePresence {
       onSync();
     });
 
-    channel.on(events.diff, {}, (diff, {ref}) {
+    channel.on(events.diff, {}, (diff, [ref]) {
       final onJoin = caller['onJoin'];
       final onLeave = caller['onLeave'];
       final onSync = caller['onSync'];

--- a/lib/src/realtime_presence.dart
+++ b/lib/src/realtime_presence.dart
@@ -1,0 +1,332 @@
+import 'package:realtime_client/src/realtime_channel.dart';
+
+class Presence {
+  final String presenceId;
+  final Map<String, dynamic> payload;
+
+  Presence(Map<String, dynamic> map)
+      : presenceId = map['presence_id'],
+        payload = map..remove('presence_id');
+
+  Presence deepClone() {
+    return Presence({'presence_id': presenceId, ...payload});
+  }
+}
+
+class PresenceState {
+  final Map<String, List<Presence>> presences;
+
+  PresenceState(this.presences);
+
+  PresenceState deepClone() {
+    return PresenceState(
+      presences,
+    );
+  }
+
+  List<String> get keys {
+    return presences.keys.toList();
+  }
+}
+
+class PresenceDiff {
+  final PresenceState joins;
+  final PresenceState leaves;
+
+  PresenceDiff({
+    required this.joins,
+    required this.leaves,
+  });
+}
+
+class RawPresenceState {
+  final Map<String, Map<String, List<Map<String, dynamic>>>> presences;
+
+  RawPresenceState(this.presences);
+}
+
+class RawPresenceDiff {
+  final RawPresenceState joins;
+  final RawPresenceState leaves;
+
+  RawPresenceDiff({required this.joins, required this.leaves});
+}
+
+typedef PresenceOnJoinCallback = void Function(
+    String? key, dynamic currentPresence, dynamic newPresence);
+
+typedef PresenceOnLeaveCallback = void Function(
+    String? key, dynamic currentPresence, dynamic newPresence);
+
+class PresenceOpts {
+  final PresenceEvents events;
+
+  PresenceOpts({required this.events});
+}
+
+class PresenceEvents {
+  final String state;
+  final String diff;
+
+  PresenceEvents({required this.state, required this.diff});
+}
+
+typedef PresenceChooser<T> = T Function(String key, dynamic presence);
+
+class RealtimePresence {
+  PresenceState state = PresenceState({});
+  List<RawPresenceDiff> pendingDiffs = [];
+  String? joinRef;
+  Map<String, dynamic> caller = {
+    'onJoin': () {},
+    'onLeave': () {},
+    'onSync': () {}
+  };
+
+  /// Initializes the Presence
+  ///
+  /// [channel] - The RealtimeChannel
+  /// [opts] - The options, for example `PresenceOpts(events: PresenceEvents(state: 'state', diff: 'diff'))`
+  RealtimePresence(RealtimeChannel channel, [PresenceOpts? opts]) {
+    final events = opts?.events ??
+        PresenceEvents(state: 'presence_state', diff: 'presence_diff');
+
+    channel.on(events.state, {}, (newState, {ref}) {
+      final onJoin = caller['onJoin'];
+      final onLeave = caller['onLeave'];
+      final onSync = caller['onSync'];
+
+      joinRef = channel.joinRef;
+
+      state = RealtimePresence.syncState(
+        state,
+        newState,
+        onJoin,
+        onLeave,
+      );
+
+      for (final diff in pendingDiffs) {
+        state = RealtimePresence.syncDiff(
+          state,
+          diff,
+          onJoin,
+          onLeave,
+        );
+      }
+
+      pendingDiffs = [];
+
+      onSync();
+    });
+
+    channel.on(events.diff, {}, (diff, {ref}) {
+      final onJoin = caller['onJoin'];
+      final onLeave = caller['onLeave'];
+      final onSync = caller['onSync'];
+
+      if (inPendingSyncState()) {
+        pendingDiffs.add(diff);
+      } else {
+        state = RealtimePresence.syncDiff(
+          state,
+          diff,
+          onJoin,
+          onLeave,
+        );
+
+        onSync();
+      }
+    });
+  }
+
+  /// Used to sync the list of presences on the server with the
+  /// client's state.
+  ///
+  /// An optional `onJoin` and `onLeave` callback can be provided to
+  /// react to changes in the client's local presences across
+  /// disconnects and reconnects with the server.
+  static PresenceState syncState(
+    PresenceState currentState,
+    dynamic newState, [
+    PresenceOnJoinCallback? onJoin,
+    PresenceOnLeaveCallback? onLeave,
+  ]) {
+    final state = currentState.deepClone();
+    final transformedState = _transformState(newState);
+    final PresenceState joins = PresenceState({});
+    final PresenceState leaves = PresenceState({});
+
+    _map(state, (key, presence) {
+      if (!transformedState.presences.containsKey(key)) {
+        leaves.presences[key] = presence;
+      }
+    });
+
+    _map(transformedState, (key, newPresences) {
+      final currentPresences = state.presences[key];
+
+      if (currentPresences != null) {
+        final newPresenceIds = newPresences.map((m) => m.presenceId).toList();
+        final curPresenceIds =
+            currentPresences.map((m) => m.presenceId).toList();
+        final joinedPresences = newPresences
+            .where((m) => !curPresenceIds.contains(m.presenceId))
+            .toList();
+        final leftPresences = currentPresences
+            .where((m) => !newPresenceIds.contains(m.presenceId))
+            .toList();
+
+        if (joinedPresences.isNotEmpty) {
+          joins.presences[key] = joinedPresences;
+        }
+
+        if (leftPresences.isNotEmpty) {
+          leaves.presences[key] = leftPresences;
+        }
+      } else {
+        joins.presences[key] = newPresences;
+      }
+    });
+
+    return syncDiff(
+        state, PresenceDiff(joins: joins, leaves: leaves), onJoin, onLeave);
+  }
+
+  /// Used to sync a diff of presence join and leave events from the
+  /// server, as they happen.
+  ///
+  /// Like `syncState`, `syncDiff` accepts optional `onJoin` and
+  /// `onLeave` callbacks to react to a user joining or leaving from a
+  /// device.
+  static PresenceState syncDiff(PresenceState state, dynamic diff,
+      [PresenceOnJoinCallback? onJoin, PresenceOnLeaveCallback? onLeave]) {
+    assert(diff is RawPresenceDiff || diff is PresenceDiff,
+        'diff must be RawPresenceDiff or RawPresenceDiff');
+    final joins = _transformState(diff.joins);
+    final leaves = _transformState(diff.leaves);
+
+    onJoin ??= (_, __, ___) => {};
+
+    onLeave ??= (_, __, ___) => {};
+
+    _map(joins, (key, newPresences) {
+      final currentPresences = state.presences[key];
+      state.presences[key] = (newPresences as List).map((presence) {
+        return presence.deepClone() as Presence;
+      }).toList();
+
+      if (currentPresences != null) {
+        final joinedPresenceIds =
+            state.presences[key]!.map((m) => m.presenceId).toList();
+        final curPresences = currentPresences
+            .where((m) => !joinedPresenceIds.contains(m.presenceId))
+            .toList();
+
+        state.presences[key]!.insertAll(0, curPresences);
+      }
+
+      onJoin!(key, currentPresences, newPresences);
+    });
+
+    _map(leaves, (key, leftPresences) {
+      var currentPresences = state.presences[key];
+
+      if (currentPresences == null) return;
+
+      final presenceIdsToRemove =
+          leftPresences.map((leftPresence) => leftPresence.presenceId).toList();
+
+      currentPresences = currentPresences
+          .where(
+              (presence) => !presenceIdsToRemove.contains(presence.presenceId))
+          .toList();
+
+      state.presences[key] = currentPresences;
+
+      onLeave!(key, currentPresences, leftPresences);
+
+      if (currentPresences.isEmpty) {
+        state.presences.remove(key);
+      }
+    });
+
+    return state;
+  }
+
+  static List<T> _map<T>(PresenceState obj, PresenceChooser<T> func) {
+    return obj.keys.map((key) => func(key, obj.presences[key]!)).toList();
+  }
+
+  /// Returns the array of presences, with selected metadata.
+  static List<T> listAll<T>(PresenceState presences,
+      [PresenceChooser<T>? chooser]) {
+    chooser ??= (key, pres) => pres;
+
+    return _map(presences, (key, presences) => chooser!(key, presences));
+  }
+
+  /// Remove 'metas' key
+  /// Change 'phx_ref' to 'presence_id'
+  /// Remove 'phx_ref' and 'phx_ref_prev'
+  ///
+  /// @example
+  /// // returns {
+  ///  abc123: [
+  ///    { presence_id: '2', user_id: 1 },
+  ///    { presence_id: '3', user_id: 2 }
+  ///  ]
+  /// }
+  /// RealtimePresence.transformState({
+  ///  abc123: {
+  ///    metas: [
+  ///      { phx_ref: '2', phx_ref_prev: '1' user_id: 1 },
+  ///      { phx_ref: '3', user_id: 2 }
+  ///    ]
+  ///  }
+  /// })
+  static PresenceState _transformState(dynamic state) {
+    assert(state is PresenceState || state is RawPresenceState,
+        'state must be a PresenceState or RawPresenceState');
+
+    final Map<String, List<Presence>> newStateMap = {};
+
+    for (final key in (state.presences as Map<String, dynamic>).keys) {
+      final presences = state.presences[key]!;
+
+      if (state is RawPresenceState) {
+        newStateMap[key] =
+            (presences['metas'] as List).map<Presence>((presence) {
+          presence['presence_id'] = presence['phx_ref'] as String;
+
+          presence.remove('phx_ref');
+          presence.remove('phx_ref_prev');
+
+          return Presence(presence);
+        }).toList();
+      } else {
+        newStateMap[key] = presences;
+      }
+    }
+    return PresenceState(newStateMap);
+  }
+
+  void onJoin(PresenceOnJoinCallback callback) {
+    caller['onJoin'] = callback;
+  }
+
+  void onLeave(PresenceOnLeaveCallback callback) {
+    caller['onLeave'] = callback;
+  }
+
+  void onSync(void Function() callback) {
+    caller['onSync'] = callback;
+  }
+
+  List<T> list<T>([PresenceChooser<T>? by]) {
+    return RealtimePresence.listAll<T>(state, by);
+  }
+
+  bool inPendingSyncState() {
+    return true;
+  }
+}

--- a/lib/src/realtime_presence.dart
+++ b/lib/src/realtime_presence.dart
@@ -31,15 +31,15 @@ class Presence {
 //   }
 // }
 
-class PresenceDiff {
-  final Map<String, dynamic> joins;
-  final Map<String, dynamic> leaves;
+// class PresenceDiff {
+//   final Map<String, dynamic> joins;
+//   final Map<String, dynamic> leaves;
 
-  PresenceDiff({
-    required this.joins,
-    required this.leaves,
-  });
-}
+//   PresenceDiff({
+//     required this.joins,
+//     required this.leaves,
+//   });
+// }
 
 // class RawPresenceState {
 //   final Map<String, Map<String, List<Map<String, dynamic>>>> presences;
@@ -47,12 +47,12 @@ class PresenceDiff {
 //   RawPresenceState(this.presences);
 // }
 
-class RawPresenceDiff {
-  final Map<String, dynamic> joins;
-  final Map<String, dynamic> leaves;
+// class RawPresenceDiff {
+//   final Map<String, dynamic> joins;
+//   final Map<String, dynamic> leaves;
 
-  RawPresenceDiff({required this.joins, required this.leaves});
-}
+//   RawPresenceDiff({required this.joins, required this.leaves});
+// }
 
 typedef PresenceChooser<T> = T Function(String key, dynamic presence);
 
@@ -77,7 +77,7 @@ class PresenceEvents {
 
 class RealtimePresence {
   var state = <String, dynamic>{};
-  List<RawPresenceDiff> pendingDiffs = [];
+  List<Map<String, dynamic>> pendingDiffs = [];
   String? joinRef;
   Map<String, dynamic> caller = {
     'onJoin': (_, __, ___) {},
@@ -197,8 +197,7 @@ class RealtimePresence {
       }
     });
 
-    return syncDiff(
-        state, PresenceDiff(joins: joins, leaves: leaves), onJoin, onLeave);
+    return syncDiff(state, {'joins': joins, 'leaves': leaves}, onJoin, onLeave);
   }
 
   /// Used to sync a diff of presence join and leave events from the
@@ -209,15 +208,12 @@ class RealtimePresence {
   /// device.
   static Map<String, dynamic> syncDiff(
     Map<String, dynamic> state,
-    dynamic diff, [
+    Map<String, dynamic> diff, [
     PresenceOnJoinCallback? onJoin,
     PresenceOnLeaveCallback? onLeave,
   ]) {
-    assert(diff is RawPresenceDiff || diff is PresenceDiff,
-        'diff must be RawPresenceDiff or RawPresenceDiff');
-
-    final joins = _transformState(diff.joins);
-    final leaves = _transformState(diff.leaves);
+    final joins = _transformState(diff['joins']);
+    final leaves = _transformState(diff['leaves']);
 
     onJoin ??= (_, __, ___) => {};
 

--- a/lib/src/realtime_presence.dart
+++ b/lib/src/realtime_presence.dart
@@ -34,7 +34,7 @@ class PresenceEvents {
   final String state;
   final String diff;
 
-  PresenceEvents({required this.state, required this.diff});
+  const PresenceEvents({required this.state, required this.diff});
 }
 
 class RealtimePresence {

--- a/lib/src/realtime_presence.dart
+++ b/lib/src/realtime_presence.dart
@@ -27,7 +27,7 @@ typedef PresenceOnLeaveCallback = void Function(
 class PresenceOpts {
   final PresenceEvents events;
 
-  PresenceOpts({required this.events});
+  const PresenceOpts({required this.events});
 }
 
 class PresenceEvents {

--- a/lib/src/realtime_presence.dart
+++ b/lib/src/realtime_presence.dart
@@ -57,10 +57,10 @@ class Presence {
 typedef PresenceChooser<T> = T Function(String key, dynamic presence);
 
 typedef PresenceOnJoinCallback = void Function(
-    String? key, dynamic currentPresence, dynamic newPresence);
+    String? key, dynamic currentPresences, dynamic newPresences);
 
 typedef PresenceOnLeaveCallback = void Function(
-    String? key, dynamic currentPresence, dynamic newPresence);
+    String? key, dynamic currentPresences, dynamic newPresences);
 
 class PresenceOpts {
   final PresenceEvents events;
@@ -142,6 +142,28 @@ class RealtimePresence {
         onSync();
       }
     });
+
+    onJoin((key, currentPresences, newPresences) {
+      channel.trigger('presence', {
+        'event': 'join',
+        'key': key,
+        'currentPresences': currentPresences,
+        'newPresences': newPresences,
+      });
+    });
+
+    onLeave((key, currentPresences, leftPresences) => {
+          channel.trigger('presence', {
+            'event': 'leave',
+            'key': key,
+            'currentPresences': currentPresences,
+            'leftPresences': leftPresences,
+          })
+        });
+
+    onSync(() => {
+          channel.trigger('presence', {'event': 'sync'})
+        });
   }
 
   /// Used to sync the list of presences on the server with the

--- a/lib/src/realtime_presence.dart
+++ b/lib/src/realtime_presence.dart
@@ -96,7 +96,7 @@ class RealtimePresence {
     final events = opts?.events ??
         PresenceEvents(state: 'presence_state', diff: 'presence_diff');
 
-    channel.on(events.state, {}, (newState, [_]) {
+    channel.on(events.state, ChannelFilter(), (newState, [_]) {
       final onJoin = caller['onJoin'];
       final onLeave = caller['onLeave'];
       final onSync = caller['onSync'];
@@ -124,7 +124,7 @@ class RealtimePresence {
       onSync();
     });
 
-    channel.on(events.diff, {}, (diff, [_]) {
+    channel.on(events.diff, ChannelFilter(), (diff, [_]) {
       final onJoin = caller['onJoin'];
       final onLeave = caller['onLeave'];
       final onSync = caller['onSync'];

--- a/lib/src/realtime_presence.dart
+++ b/lib/src/realtime_presence.dart
@@ -279,15 +279,13 @@ class RealtimePresence {
   ///  }
   /// })
   static Map<String, dynamic> _transformState(Map<String, dynamic> state) {
-    // assert(state is PresenceState || state is RawPresenceState,
-    //     'state must be a PresenceState or RawPresenceState');
-
     final Map<String, List<Presence>> newStateMap = {};
 
     for (final key in state.keys) {
       final presences = state[key]!;
 
-      if (presences.keys.contains('metas')) {
+      // if (presences.keys.contains('metas')) {
+      if (presences is Map) {
         newStateMap[key] =
             (presences['metas'] as List).map<Presence>((presence) {
           presence['presence_ref'] = presence['phx_ref'] as String;
@@ -298,6 +296,7 @@ class RealtimePresence {
           return Presence(presence);
         }).toList();
       } else {
+        // presences is List<Presence>
         newStateMap[key] =
             (presences as List).map((map) => Presence(map)).toList();
       }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '0.1.15';
+const version = '1.0.0-dev.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: realtime_client
 description: Listens to changes in a PostgreSQL Database and via websockets. This is for usage with Supabase Realtime server.
-version: 0.1.15
+version: 1.0.0-dev.1
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/realtime-dart'
 

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -129,7 +129,7 @@ void main() {
     test('sets up callback for event', () {
       var callbackCalled = 0;
       channel.onEvents('event', ChannelFilter(),
-          (dynamic payload, [String? ref]) => callbackCalled++);
+          (dynamic payload, [dynamic ref]) => callbackCalled++);
 
       channel.trigger('event', {});
       expect(callbackCalled, 1);
@@ -141,12 +141,12 @@ void main() {
       channel.onEvents(
         'event',
         ChannelFilter(),
-        (dynamic payload, [String? ref]) => eventCallbackCalled++,
+        (dynamic payload, [dynamic ref]) => eventCallbackCalled++,
       );
       channel.onEvents(
         'otherEvent',
         ChannelFilter(),
-        (dynamic payload, [String? ref]) => otherEventCallbackCalled++,
+        (dynamic payload, [dynamic ref]) => otherEventCallbackCalled++,
       );
 
       channel.trigger('event', {});
@@ -157,7 +157,7 @@ void main() {
     test('"*" bind all events', () {
       var callbackCalled = 0;
       channel.onEvents('realtime', ChannelFilter(event: '*'),
-          (dynamic payload, [String? ref]) => callbackCalled++);
+          (dynamic payload, [dynamic ref]) => callbackCalled++);
 
       channel.trigger('realtime', {'event': 'INSERT'});
       channel.trigger('realtime', {'event': 'UPDATE'});
@@ -179,11 +179,11 @@ void main() {
       var callbackOtherCalled = 0;
 
       channel.onEvents('event', ChannelFilter(),
-          (dynamic payload, [String? ref]) => callBackEventCalled1++);
+          (dynamic payload, [dynamic ref]) => callBackEventCalled1++);
       channel.onEvents('event', ChannelFilter(),
-          (dynamic payload, [String? ref]) => callbackEventCalled2++);
+          (dynamic payload, [dynamic ref]) => callbackEventCalled2++);
       channel.onEvents('other', ChannelFilter(),
-          (dynamic payload, [String? ref]) => callbackOtherCalled++);
+          (dynamic payload, [dynamic ref]) => callbackOtherCalled++);
 
       channel.off('event', {});
 

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -67,7 +67,7 @@ void main() {
 
       expect(joinPush.timeout, Constants.defaultTimeout);
 
-      channel.subscribe(() {}, newTimeout);
+      channel.subscribe((_, [__]) {}, newTimeout);
 
       expect(joinPush.timeout, newTimeout);
     });

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -18,7 +18,8 @@ void main() {
   group('constructor', () {
     setUp(() {
       socket = RealtimeClient('', timeout: const Duration(milliseconds: 1234));
-      channel = RealtimeChannel('topic', socket, params: ChannelParams());
+      channel =
+          RealtimeChannel('topic', socket, params: RealtimeChannelConfig());
     });
 
     test('sets defaults', () {

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -128,7 +128,7 @@ void main() {
 
     test('sets up callback for event', () {
       var callbackCalled = 0;
-      channel.on('event', ChannelFilter(),
+      channel.onEvents('event', ChannelFilter(),
           (dynamic payload, [String? ref]) => callbackCalled++);
 
       channel.trigger('event', {});
@@ -138,12 +138,12 @@ void main() {
     test('other event callbacks are ignored', () {
       var eventCallbackCalled = 0;
       var otherEventCallbackCalled = 0;
-      channel.on(
+      channel.onEvents(
         'event',
         ChannelFilter(),
         (dynamic payload, [String? ref]) => eventCallbackCalled++,
       );
-      channel.on(
+      channel.onEvents(
         'otherEvent',
         ChannelFilter(),
         (dynamic payload, [String? ref]) => otherEventCallbackCalled++,
@@ -156,7 +156,7 @@ void main() {
 
     test('"*" bind all events', () {
       var callbackCalled = 0;
-      channel.on('realtime', ChannelFilter(event: '*'),
+      channel.onEvents('realtime', ChannelFilter(event: '*'),
           (dynamic payload, [String? ref]) => callbackCalled++);
 
       channel.trigger('realtime', {'event': 'INSERT'});
@@ -178,11 +178,11 @@ void main() {
       var callbackEventCalled2 = 0;
       var callbackOtherCalled = 0;
 
-      channel.on('event', ChannelFilter(),
+      channel.onEvents('event', ChannelFilter(),
           (dynamic payload, [String? ref]) => callBackEventCalled1++);
-      channel.on('event', ChannelFilter(),
+      channel.onEvents('event', ChannelFilter(),
           (dynamic payload, [String? ref]) => callbackEventCalled2++);
-      channel.on('other', ChannelFilter(),
+      channel.onEvents('other', ChannelFilter(),
           (dynamic payload, [String? ref]) => callbackOtherCalled++);
 
       channel.off('event', {});
@@ -226,7 +226,7 @@ void main() {
     });
 
     test("able to unsubscribe from * subscription", () {
-      channel.on('*', ChannelFilter(), (payload, [ref]) {});
+      channel.onEvents('*', ChannelFilter(), (payload, [ref]) {});
       expect(socket.channels.length, 1);
 
       channel.unsubscribe();

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -3,12 +3,12 @@ import 'package:test/test.dart';
 
 void main() {
   late RealtimeClient socket;
-  late RealtimeSubscription channel;
+  late RealtimeChannel channel;
 
   const defaultRef = '1';
 
   test('channel should be initially closed', () {
-    final channel = RealtimeSubscription('topic', RealtimeClient('endpoint'));
+    final channel = RealtimeChannel('topic', RealtimeClient('endpoint'));
     expect(channel.isClosed, isTrue);
     channel.rejoin(const Duration(seconds: 5));
     expect(channel.isJoining, isTrue);
@@ -17,7 +17,7 @@ void main() {
   group('constructor', () {
     setUp(() {
       socket = RealtimeClient('', timeout: const Duration(milliseconds: 1234));
-      channel = RealtimeSubscription('topic', socket, params: {'one': 'two'});
+      channel = RealtimeChannel('topic', socket, params: {'one': 'two'});
     });
 
     test('sets defaults', () {
@@ -101,15 +101,16 @@ void main() {
   });
 
   group('on', () {
-    late RealtimeSubscription channel;
+    late RealtimeChannel channel;
 
     setUp(() {
-      channel = RealtimeSubscription('topic', RealtimeClient('endpoint'));
+      channel = RealtimeChannel('topic', RealtimeClient('endpoint'));
     });
 
     test('sets up callback for event', () {
       var callbackCalled = 0;
-      channel.on('event', (dynamic payload, {String? ref}) => callbackCalled++);
+      channel.on(
+          'event', {}, (dynamic payload, {String? ref}) => callbackCalled++);
 
       channel.trigger('event', payload: {});
       expect(callbackCalled, 1);
@@ -120,10 +121,12 @@ void main() {
       var otherEventCallbackCalled = 0;
       channel.on(
         'event',
+        {},
         (dynamic payload, {String? ref}) => eventCallbackCalled++,
       );
       channel.on(
         'otherEvent',
+        {},
         (dynamic payload, {String? ref}) => otherEventCallbackCalled++,
       );
 
@@ -134,7 +137,8 @@ void main() {
 
     test('"*" bind all events', () {
       var callbackCalled = 0;
-      channel.on('*', (dynamic payload, {String? ref}) => callbackCalled++);
+      channel.on('*', {'event': 'INSERT'},
+          (dynamic payload, {String? ref}) => callbackCalled++);
 
       channel.trigger('INSERT', payload: {});
       expect(callbackCalled, 0);
@@ -163,14 +167,17 @@ void main() {
 
       channel.on(
         'event',
+        {},
         (dynamic payload, {String? ref}) => callBackEventCalled1++,
       );
       channel.on(
         'event',
+        {},
         (dynamic payload, {String? ref}) => callbackEventCalled2++,
       );
       channel.on(
         'other',
+        {},
         (dynamic payload, {String? ref}) => callbackOtherCalled++,
       );
 
@@ -213,7 +220,7 @@ void main() {
     });
 
     test("able to unsubscribe from * subscription", () {
-      channel.on('*', (payload, {ref}) {});
+      channel.on('*', {}, (payload, {ref}) {});
       expect(socket.channels.length, 1);
 
       channel.unsubscribe().trigger('ok', {});

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -137,18 +137,12 @@ void main() {
 
     test('"*" bind all events', () {
       var callbackCalled = 0;
-      channel.on('*', {'event': 'INSERT'},
+      channel.on('realtime', {'event': '*'},
           (dynamic payload, [String? ref]) => callbackCalled++);
 
-      channel.trigger('INSERT', {});
-      expect(callbackCalled, 0);
-
-      channel.trigger('*', {'type': 'INSERT'});
-      expect(callbackCalled, 0);
-
-      channel.trigger('INSERT', {'type': 'INSERT'});
-      channel.trigger('UPDATE', {'type': 'UPDATE'});
-      channel.trigger('DELETE', {'type': 'DELETE'});
+      channel.trigger('realtime', {'event': 'INSERT'});
+      channel.trigger('realtime', {'event': 'UPDATE'});
+      channel.trigger('realtime', {'event': 'DELETE'});
       expect(callbackCalled, 3);
     });
   });

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -31,7 +31,7 @@ void main() {
   group('join', () {
     setUp(() {
       socket = RealtimeClient('wss://example.com/socket');
-      channel = socket.channel('topic', chanParams: {'one': 'two'});
+      channel = socket.channel('topic', {'one': 'two'});
     });
 
     test('sets state to joining', () {
@@ -57,7 +57,7 @@ void main() {
   group('onError', () {
     setUp(() {
       socket = RealtimeClient('/socket');
-      channel = socket.channel('topic', chanParams: {'one': 'two'});
+      channel = socket.channel('topic', {'one': 'two'});
       channel.subscribe();
     });
 
@@ -73,7 +73,7 @@ void main() {
   group('onClose', () {
     setUp(() {
       socket = RealtimeClient('/socket');
-      channel = socket.channel('topic', chanParams: {'one': 'two'});
+      channel = socket.channel('topic', {'one': 'two'});
       channel.subscribe();
     });
 
@@ -90,7 +90,7 @@ void main() {
     setUp(() {
       socket = RealtimeClient('/socket');
 
-      channel = socket.channel('topic', chanParams: {'one': 'two'});
+      channel = socket.channel('topic', {'one': 'two'});
     });
 
     test('returns payload by default', () {
@@ -110,9 +110,9 @@ void main() {
     test('sets up callback for event', () {
       var callbackCalled = 0;
       channel.on(
-          'event', {}, (dynamic payload, {String? ref}) => callbackCalled++);
+          'event', {}, (dynamic payload, [String? ref]) => callbackCalled++);
 
-      channel.trigger('event', payload: {});
+      channel.trigger('event', {});
       expect(callbackCalled, 1);
     });
 
@@ -122,15 +122,15 @@ void main() {
       channel.on(
         'event',
         {},
-        (dynamic payload, {String? ref}) => eventCallbackCalled++,
+        (dynamic payload, [String? ref]) => eventCallbackCalled++,
       );
       channel.on(
         'otherEvent',
         {},
-        (dynamic payload, {String? ref}) => otherEventCallbackCalled++,
+        (dynamic payload, [String? ref]) => otherEventCallbackCalled++,
       );
 
-      channel.trigger('event', payload: {});
+      channel.trigger('event', {});
       expect(eventCallbackCalled, 1);
       expect(otherEventCallbackCalled, 0);
     });
@@ -138,17 +138,17 @@ void main() {
     test('"*" bind all events', () {
       var callbackCalled = 0;
       channel.on('*', {'event': 'INSERT'},
-          (dynamic payload, {String? ref}) => callbackCalled++);
+          (dynamic payload, [String? ref]) => callbackCalled++);
 
-      channel.trigger('INSERT', payload: {});
+      channel.trigger('INSERT', {});
       expect(callbackCalled, 0);
 
-      channel.trigger('*', payload: {'type': 'INSERT'});
+      channel.trigger('*', {'type': 'INSERT'});
       expect(callbackCalled, 0);
 
-      channel.trigger('INSERT', payload: {'type': 'INSERT'});
-      channel.trigger('UPDATE', payload: {'type': 'UPDATE'});
-      channel.trigger('DELETE', payload: {'type': 'DELETE'});
+      channel.trigger('INSERT', {'type': 'INSERT'});
+      channel.trigger('UPDATE', {'type': 'UPDATE'});
+      channel.trigger('DELETE', {'type': 'DELETE'});
       expect(callbackCalled, 3);
     });
   });
@@ -157,7 +157,7 @@ void main() {
     setUp(() {
       socket = RealtimeClient('/socket');
 
-      channel = socket.channel('topic', chanParams: {'one': 'two'});
+      channel = socket.channel('topic', {'one': 'two'});
     });
 
     test('removes all callbacks for event', () {
@@ -168,23 +168,23 @@ void main() {
       channel.on(
         'event',
         {},
-        (dynamic payload, {String? ref}) => callBackEventCalled1++,
+        (dynamic payload, [String? ref]) => callBackEventCalled1++,
       );
       channel.on(
         'event',
         {},
-        (dynamic payload, {String? ref}) => callbackEventCalled2++,
+        (dynamic payload, [String? ref]) => callbackEventCalled2++,
       );
       channel.on(
         'other',
         {},
-        (dynamic payload, {String? ref}) => callbackOtherCalled++,
+        (dynamic payload, [String? ref]) => callbackOtherCalled++,
       );
 
-      channel.off('event');
+      channel.off('event', {});
 
-      channel.trigger('event', payload: {}, ref: defaultRef);
-      channel.trigger('other', payload: {}, ref: defaultRef);
+      channel.trigger('event', {}, defaultRef);
+      channel.trigger('other', {}, defaultRef);
 
       expect(callBackEventCalled1, 0);
       expect(callbackEventCalled2, 0);
@@ -196,13 +196,12 @@ void main() {
     setUp(() {
       socket = RealtimeClient('/socket');
 
-      channel = socket.channel('topic', chanParams: {'one': 'two'});
+      channel = socket.channel('topic', {'one': 'two'});
       channel.subscribe().trigger('ok', {});
     });
 
     test("closes channel on 'ok' from server", () {
-      final anotherChannel =
-          socket.channel('another', chanParams: {'three': 'four'});
+      final anotherChannel = socket.channel('another', {'three': 'four'});
       expect(socket.channels.length, 2);
 
       channel.unsubscribe().trigger('ok', {});
@@ -220,7 +219,7 @@ void main() {
     });
 
     test("able to unsubscribe from * subscription", () {
-      channel.on('*', {}, (payload, {ref}) {});
+      channel.on('*', {}, (payload, [ref]) {});
       expect(socket.channels.length, 1);
 
       channel.unsubscribe().trigger('ok', {});

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -18,7 +18,7 @@ void main() {
   group('constructor', () {
     setUp(() {
       socket = RealtimeClient('', timeout: const Duration(milliseconds: 1234));
-      channel = RealtimeChannel('topic', socket, params: {'one': 'two'});
+      channel = RealtimeChannel('topic', socket, params: ChannelParams());
     });
 
     test('sets defaults', () {
@@ -28,8 +28,7 @@ void main() {
         'config': {
           'broadcast': {'ack': false, 'self': false},
           'presence': {'key': ''}
-        },
-        'one': 'two'
+        }
       });
       expect(channel.socket, socket);
     });
@@ -38,7 +37,7 @@ void main() {
   group('join', () {
     setUp(() {
       socket = RealtimeClient('wss://example.com/socket');
-      channel = socket.channel('topic', {'one': 'two'});
+      channel = socket.channel('topic');
     });
 
     test('sets state to joining', () {
@@ -76,7 +75,7 @@ void main() {
   group('onError', () {
     setUp(() {
       socket = RealtimeClient('/socket');
-      channel = socket.channel('topic', {'one': 'two'});
+      channel = socket.channel('topic');
       channel.subscribe();
     });
 
@@ -92,7 +91,7 @@ void main() {
   group('onClose', () {
     setUp(() {
       socket = RealtimeClient('/socket');
-      channel = socket.channel('topic', {'one': 'two'});
+      channel = socket.channel('topic');
       channel.subscribe();
     });
 
@@ -109,7 +108,7 @@ void main() {
     setUp(() {
       socket = RealtimeClient('/socket');
 
-      channel = socket.channel('topic', {'one': 'two'});
+      channel = socket.channel('topic');
     });
 
     test('returns payload by default', () {
@@ -170,7 +169,7 @@ void main() {
     setUp(() {
       socket = RealtimeClient('/socket');
 
-      channel = socket.channel('topic', {'one': 'two'});
+      channel = socket.channel('topic');
     });
 
     test('removes all callbacks for event', () {
@@ -200,13 +199,13 @@ void main() {
     setUp(() {
       socket = RealtimeClient('/socket');
 
-      channel = socket.channel('topic', {'one': 'two'});
+      channel = socket.channel('topic');
       channel.subscribe();
       channel.joinPush.trigger('ok', {});
     });
 
     test("closes channel on 'ok' from server", () {
-      final anotherChannel = socket.channel('another', {'three': 'four'});
+      final anotherChannel = socket.channel('another');
       expect(socket.channels.length, 2);
 
       channel.unsubscribe();

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -24,7 +24,13 @@ void main() {
     test('sets defaults', () {
       expect(channel.isClosed, true);
       expect(channel.topic, 'topic');
-      expect(channel.params, {'one': 'two'});
+      expect(channel.params, {
+        'configs': {
+          'broadcast': {'ack': false, 'self': false},
+          'presence': {'key': ''}
+        },
+        'one': 'two'
+      });
       expect(channel.socket, socket);
     });
   });

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -25,7 +25,7 @@ void main() {
       expect(channel.isClosed, true);
       expect(channel.topic, 'topic');
       expect(channel.params, {
-        'configs': {
+        'config': {
           'broadcast': {'ack': false, 'self': false},
           'presence': {'key': ''}
         },
@@ -128,8 +128,8 @@ void main() {
 
     test('sets up callback for event', () {
       var callbackCalled = 0;
-      channel.on(
-          'event', {}, (dynamic payload, [String? ref]) => callbackCalled++);
+      channel.on('event', ChannelFilter(),
+          (dynamic payload, [String? ref]) => callbackCalled++);
 
       channel.trigger('event', {});
       expect(callbackCalled, 1);
@@ -140,12 +140,12 @@ void main() {
       var otherEventCallbackCalled = 0;
       channel.on(
         'event',
-        {},
+        ChannelFilter(),
         (dynamic payload, [String? ref]) => eventCallbackCalled++,
       );
       channel.on(
         'otherEvent',
-        {},
+        ChannelFilter(),
         (dynamic payload, [String? ref]) => otherEventCallbackCalled++,
       );
 
@@ -156,7 +156,7 @@ void main() {
 
     test('"*" bind all events', () {
       var callbackCalled = 0;
-      channel.on('realtime', {'event': '*'},
+      channel.on('realtime', ChannelFilter(event: '*'),
           (dynamic payload, [String? ref]) => callbackCalled++);
 
       channel.trigger('realtime', {'event': 'INSERT'});
@@ -178,11 +178,11 @@ void main() {
       var callbackEventCalled2 = 0;
       var callbackOtherCalled = 0;
 
-      channel.on('event', {},
+      channel.on('event', ChannelFilter(),
           (dynamic payload, [String? ref]) => callBackEventCalled1++);
-      channel.on('event', {},
+      channel.on('event', ChannelFilter(),
           (dynamic payload, [String? ref]) => callbackEventCalled2++);
-      channel.on('other', {},
+      channel.on('other', ChannelFilter(),
           (dynamic payload, [String? ref]) => callbackOtherCalled++);
 
       channel.off('event', {});
@@ -226,7 +226,7 @@ void main() {
     });
 
     test("able to unsubscribe from * subscription", () {
-      channel.on('*', {}, (payload, [ref]) {});
+      channel.on('*', ChannelFilter(), (payload, [ref]) {});
       expect(socket.channels.length, 1);
 
       channel.unsubscribe();

--- a/test/socket_test.dart
+++ b/test/socket_test.dart
@@ -264,7 +264,7 @@ void main() {
 
   group('channel', () {
     const tTopic = 'topic';
-    const tParams = {'one': 'two'};
+    const tParams = ChannelParams();
     late RealtimeClient socket;
     setUp(() {
       socket = RealtimeClient(socketEndpoint);
@@ -286,8 +286,7 @@ void main() {
         'config': {
           'broadcast': {'ack': false, 'self': false},
           'presence': {'key': ''}
-        },
-        'one': 'two'
+        }
       });
     });
 

--- a/test/socket_test.dart
+++ b/test/socket_test.dart
@@ -298,7 +298,7 @@ void main() {
       const tTopic2 = 'topic-2';
 
       final mockedSocket = SocketWithMockedChannel(socketEndpoint);
-      mockedSocket.mockedChannelLooker.addAll(<String, RealtimeSubscription>{
+      mockedSocket.mockedChannelLooker.addAll(<String, RealtimeChannel>{
         tTopic1: mockedChannel1,
         tTopic2: mockedChannel2,
       });
@@ -463,7 +463,7 @@ void main() {
       const tTopic2 = 'topic-2';
 
       final mockedSocket = SocketWithMockedChannel(socketEndpoint);
-      mockedSocket.mockedChannelLooker.addAll(<String, RealtimeSubscription>{
+      mockedSocket.mockedChannelLooker.addAll(<String, RealtimeChannel>{
         tTopic1: mockedChannel1,
         tTopic2: mockedChannel2,
       });

--- a/test/socket_test.dart
+++ b/test/socket_test.dart
@@ -264,7 +264,7 @@ void main() {
 
   group('channel', () {
     const tTopic = 'topic';
-    const tParams = ChannelParams();
+    const tParams = RealtimeChannelConfig();
     late RealtimeClient socket;
     setUp(() {
       socket = RealtimeClient(socketEndpoint);

--- a/test/socket_test.dart
+++ b/test/socket_test.dart
@@ -140,6 +140,11 @@ void main() {
     setUp(() {
       socket = RealtimeClient('ws://localhost:${mockServer.port}');
     });
+
+    tearDown(() {
+      socket.disconnect();
+    });
+
     test('establishes websocket connection with endpoint', () {
       socket.connect();
 
@@ -201,9 +206,14 @@ void main() {
     setUp(() {
       socket = RealtimeClient('ws://localhost:${mockServer.port}');
     });
+
+    tearDown(() {
+      socket.disconnect();
+    });
+
     test('removes existing connection', () async {
       socket.connect();
-      await socket.disconnect();
+      socket.disconnect();
 
       expect(socket.conn, null);
     });
@@ -211,7 +221,7 @@ void main() {
     test('calls callback', () async {
       int closes = 0;
       socket.connect();
-      await socket.disconnect();
+      socket.disconnect();
       closes += 1;
 
       expect(closes, 1);
@@ -260,6 +270,10 @@ void main() {
       socket = RealtimeClient(socketEndpoint);
     });
 
+    tearDown(() {
+      socket.disconnect();
+    });
+
     test('returns channel with given topic and params', () {
       final channel = socket.channel(
         tTopic,
@@ -267,8 +281,14 @@ void main() {
       );
 
       expect(channel.socket, socket);
-      expect(channel.topic, tTopic);
-      expect(channel.params, tParams);
+      expect(channel.topic, 'realtime:topic');
+      expect(channel.params, {
+        'configs': {
+          'broadcast': {'ack': false, 'self': false},
+          'presence': {'key': ''}
+        },
+        'one': 'two'
+      });
     });
 
     test('adds channel to sockets channels list', () {
@@ -381,6 +401,10 @@ void main() {
       socket = RealtimeClient(socketEndpoint);
     });
 
+    tearDown(() {
+      socket.disconnect();
+    });
+
     test('returns next message ref', () {
       expect(socket.ref, 0);
       expect(socket.makeRef(), '1');
@@ -393,6 +417,48 @@ void main() {
       socket.ref = int64MaxValue;
       expect(socket.makeRef(), '0');
       expect(socket.ref, 0);
+    });
+  });
+
+  group('setAuth', () {
+    final updateJoinPayload = {'user_token': 'token123'};
+    final pushPayload = {'access_token': 'token123'};
+
+    test(
+        "sets access token, updates channels' join payload, and pushes token to channels",
+        () {
+      final mockedChannel1 = MockChannel();
+      when(() => mockedChannel1.joinedOnce).thenReturn(true);
+      when(() => mockedChannel1.isJoined).thenReturn(true);
+      when(() => mockedChannel1.push(ChannelEvents.accessToken, pushPayload))
+          .thenReturn(MockPush());
+
+      final mockedChannel2 = MockChannel();
+      when(() => mockedChannel2.joinedOnce).thenReturn(true);
+      when(() => mockedChannel2.isJoined).thenReturn(true);
+      when(() => mockedChannel2.push(ChannelEvents.accessToken, pushPayload))
+          .thenReturn(MockPush());
+
+      const tTopic1 = 'topic-1';
+      const tTopic2 = 'topic-2';
+
+      final mockedSocket = SocketWithMockedChannel(socketEndpoint);
+      mockedSocket.mockedChannelLooker.addAll(<String, RealtimeChannel>{
+        tTopic1: mockedChannel1,
+        tTopic2: mockedChannel2,
+      });
+
+      final channel1 = mockedSocket.channel(tTopic1);
+      final channel2 = mockedSocket.channel(tTopic2);
+
+      mockedSocket.setAuth('token123');
+
+      verify(() => channel1.updateJoinPayload(updateJoinPayload)).called(1);
+      verify(() => channel2.updateJoinPayload(updateJoinPayload)).called(1);
+      verify(() => channel1.push(ChannelEvents.accessToken, pushPayload))
+          .called(1);
+      verify(() => channel2.push(ChannelEvents.accessToken, pushPayload))
+          .called(1);
     });
   });
 
@@ -437,48 +503,6 @@ void main() {
 
       mockedSocket.sendHeartbeat();
       verifyNever(() => mockedSink.add(any()));
-    });
-  });
-
-  group('setAuth', () {
-    final updateJoinPayload = {'user_token': 'token123'};
-    final pushPayload = {'access_token': 'token123'};
-
-    test(
-        "sets access token, updates channels' join payload, and pushes token to channels",
-        () {
-      final mockedChannel1 = MockChannel();
-      when(() => mockedChannel1.joinedOnce).thenReturn(true);
-      when(() => mockedChannel1.isJoined).thenReturn(true);
-      when(() => mockedChannel1.push(ChannelEvents.accessToken, pushPayload))
-          .thenReturn(MockPush());
-
-      final mockedChannel2 = MockChannel();
-      when(() => mockedChannel2.joinedOnce).thenReturn(true);
-      when(() => mockedChannel2.isJoined).thenReturn(true);
-      when(() => mockedChannel2.push(ChannelEvents.accessToken, pushPayload))
-          .thenReturn(MockPush());
-
-      const tTopic1 = 'topic-1';
-      const tTopic2 = 'topic-2';
-
-      final mockedSocket = SocketWithMockedChannel(socketEndpoint);
-      mockedSocket.mockedChannelLooker.addAll(<String, RealtimeChannel>{
-        tTopic1: mockedChannel1,
-        tTopic2: mockedChannel2,
-      });
-
-      final channel1 = mockedSocket.channel(tTopic1);
-      final channel2 = mockedSocket.channel(tTopic2);
-
-      mockedSocket.setAuth('token123');
-
-      verify(() => channel1.updateJoinPayload(updateJoinPayload)).called(1);
-      verify(() => channel2.updateJoinPayload(updateJoinPayload)).called(1);
-      verify(() => channel1.push(ChannelEvents.accessToken, pushPayload))
-          .called(1);
-      verify(() => channel2.push(ChannelEvents.accessToken, pushPayload))
-          .called(1);
     });
   });
 }

--- a/test/socket_test.dart
+++ b/test/socket_test.dart
@@ -263,7 +263,7 @@ void main() {
     test('returns channel with given topic and params', () {
       final channel = socket.channel(
         tTopic,
-        chanParams: tParams,
+        tParams,
       );
 
       expect(channel.socket, socket);
@@ -276,7 +276,7 @@ void main() {
 
       final channel = socket.channel(
         tTopic,
-        chanParams: tParams,
+        tParams,
       );
 
       expect(socket.channels.length, 1);

--- a/test/socket_test.dart
+++ b/test/socket_test.dart
@@ -283,7 +283,7 @@ void main() {
       expect(channel.socket, socket);
       expect(channel.topic, 'realtime:topic');
       expect(channel.params, {
-        'configs': {
+        'config': {
           'broadcast': {'ack': false, 'self': false},
           'presence': {'key': ''}
         },

--- a/test/socket_test_stubs.dart
+++ b/test/socket_test_stubs.dart
@@ -20,7 +20,7 @@ class SocketWithMockedChannel extends RealtimeClient {
   @override
   RealtimeChannel channel(
     String topic, [
-    Map<String, dynamic> chanParams = const {},
+    Map<String, dynamic>? chanParams = const {},
   ]) {
     if (mockedChannelLooker.keys.contains(topic)) {
       channels.add(mockedChannelLooker[topic]!);

--- a/test/socket_test_stubs.dart
+++ b/test/socket_test_stubs.dart
@@ -20,7 +20,7 @@ class SocketWithMockedChannel extends RealtimeClient {
   @override
   RealtimeChannel channel(
     String topic, [
-    ChannelParams chanParams = const ChannelParams(),
+    RealtimeChannelConfig chanParams = const RealtimeChannelConfig(),
   ]) {
     if (mockedChannelLooker.keys.contains(topic)) {
       channels.add(mockedChannelLooker[topic]!);

--- a/test/socket_test_stubs.dart
+++ b/test/socket_test_stubs.dart
@@ -8,17 +8,17 @@ class MockIOWebSocketChannel extends Mock implements IOWebSocketChannel {}
 
 class MockWebSocketSink extends Mock implements WebSocketSink {}
 
-class MockChannel extends Mock implements RealtimeSubscription {}
+class MockChannel extends Mock implements RealtimeChannel {}
 
 class MockPush extends Mock implements Push {}
 
 class SocketWithMockedChannel extends RealtimeClient {
   SocketWithMockedChannel(String endPoint) : super(endPoint);
 
-  Map<String, RealtimeSubscription> mockedChannelLooker = {};
+  Map<String, RealtimeChannel> mockedChannelLooker = {};
 
   @override
-  RealtimeSubscription channel(
+  RealtimeChannel channel(
     String topic, {
     Map<String, dynamic> chanParams = const {},
   }) {

--- a/test/socket_test_stubs.dart
+++ b/test/socket_test_stubs.dart
@@ -19,14 +19,14 @@ class SocketWithMockedChannel extends RealtimeClient {
 
   @override
   RealtimeChannel channel(
-    String topic, {
+    String topic, [
     Map<String, dynamic> chanParams = const {},
-  }) {
+  ]) {
     if (mockedChannelLooker.keys.contains(topic)) {
       channels.add(mockedChannelLooker[topic]!);
       return mockedChannelLooker[topic]!;
     } else {
-      return super.channel(topic, chanParams: chanParams);
+      return super.channel(topic, chanParams);
     }
   }
 }

--- a/test/socket_test_stubs.dart
+++ b/test/socket_test_stubs.dart
@@ -20,7 +20,7 @@ class SocketWithMockedChannel extends RealtimeClient {
   @override
   RealtimeChannel channel(
     String topic, [
-    Map<String, dynamic>? chanParams = const {},
+    ChannelParams chanParams = const ChannelParams(),
   ]) {
     if (mockedChannelLooker.keys.contains(topic)) {
       channels.add(mockedChannelLooker[topic]!);


### PR DESCRIPTION
Sorry for the massive one. 

With the most recent update in Realtime, two new features were added, [broadcast](https://supabase.com/docs/guides/realtime/broadcast) and [presence](https://supabase.com/docs/guides/realtime/presence). 

This is the my proposal for the new realtime-dart API

```dart
final socket = RealtimeClient('ws://SUPABASE_API_ENDPOINT/realtime/v1');
final channel = socket.channel('can_be_any_string');

// listen to insert events on public.messages table
channel.on(
    RealtimeListenTypes.postgresChanges,
    ChannelFilter(
      event: 'INSERT',
      schema: 'public',
      table: 'messages',
    ), (payload, [ref]) {
  print('database insert payload: $payload');
});

// listen to `location` broadcast events
channel.on(
    RealtimeListenTypes.broadcast,
    ChannelFilter(
      event: 'location',
    ), (payload, [ref]) {
  print(payload);
});

// send `location` broadcast events
channel.send(
  type: RealtimeListenTypes.broadcast,
  event: 'location',
  payload: {'lat': 1.3521, 'lng': 103.8198},
);

// listen to presence states
channel.on(RealtimeListenTypes.presence, ChannelFilter(event: 'sync'),
    (payload, [ref]) {
  print(payload);
  print(channel.presenceState());
});

// subscribe to the above changes
channel.subscribe((status) async {
  if (status == 'SUBSCRIBED') {
    // if subscribed successfully, send presence event
    final status = await channel.track({'user_id': myUserId});
  }
});
```