### PR TITLE
fix: bug where presence sync of other clients causes exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.0-dev.2]
+
+- fix: bug where presence sync of other clients causes exception
+
 ## [1.0.0-dev.1]
 
 - feat: add support for broadcast and presence

--- a/lib/src/realtime_presence.dart
+++ b/lib/src/realtime_presence.dart
@@ -297,8 +297,7 @@ class RealtimePresence {
         }).toList();
       } else {
         // presences is List<Presence>
-        newStateMap[key] =
-            (presences as List).map((map) => Presence(map)).toList();
+        newStateMap[key] = presences;
       }
     }
     return newStateMap;

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.0.0-dev.1';
+const version = '1.0.0-dev.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: realtime_client
 description: Listens to changes in a PostgreSQL Database and via websockets. This is for usage with Supabase Realtime server.
-version: 1.0.0-dev.1
+version: 1.0.0-dev.2
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/realtime-dart'
 


### PR DESCRIPTION
This was the part that was causing exception. Specifically, ` Presence(map)` was the cause. I was trying to pass a variable `map`, which has type `Presence` into a constructor of `Presence`, which takes a `Map` 😂

```dart
// presences is List<Presence>
newStateMap[key] =
            (presences as List).map((map) => Presence(map)).toList();
```