### PR TITLE
BREAKING: enrich paylaod for old versions of realtime as well.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.0-dev.3]
+
+- BREAKING: fix payload shape on old version of realtime server to match the new version
+
 ## [1.0.0-dev.2]
 
 - fix: bug where presence sync of other clients causes exception

--- a/lib/src/realtime_channel.dart
+++ b/lib/src/realtime_channel.dart
@@ -542,6 +542,7 @@ class RealtimeChannel {
       });
 
       for (final bind in (bindings ?? <Binding>[])) {
+        handledPayload = _getEnrichedPayload(handledPayload);
         bind.callback(handledPayload, ref);
       }
     } else {
@@ -567,26 +568,7 @@ class RealtimeChannel {
       });
       for (final bind in bindings) {
         if (handledPayload is Map && handledPayload.keys.contains('ids')) {
-          final postgresChanges = handledPayload['data'];
-          final schema = postgresChanges['schema'];
-          final table = postgresChanges['table'];
-          final commitTimestamp = postgresChanges['commit_timestamp'];
-          final type = postgresChanges['type'];
-          final errors = postgresChanges['errors'];
-
-          final enrichedPayload = {
-            'schema': schema,
-            'table': table,
-            'commit_timestamp': commitTimestamp,
-            'eventType': type,
-            'new': {},
-            'old': {},
-            'errors': errors,
-          };
-          handledPayload = {
-            ...enrichedPayload,
-            ..._getPayloadRecords(postgresChanges),
-          };
+          handledPayload = _getEnrichedPayload(handledPayload);
         }
 
         bind.callback(handledPayload, ref);
@@ -620,6 +602,30 @@ class RealtimeChannel {
     }
 
     return true;
+  }
+
+  Map<String, dynamic> _getEnrichedPayload(dynamic payload) {
+    final postgresChanges = payload['data'];
+    final schema = postgresChanges['schema'];
+    final table = postgresChanges['table'];
+    final commitTimestamp = postgresChanges['commit_timestamp'];
+    final type = postgresChanges['type'];
+    final errors = postgresChanges['errors'];
+
+    final enrichedPayload = {
+      'schema': schema,
+      'table': table,
+      'commit_timestamp': commitTimestamp,
+      'eventType': type,
+      'new': {},
+      'old': {},
+      'errors': errors,
+    };
+
+    return {
+      ...enrichedPayload,
+      ..._getPayloadRecords(postgresChanges),
+    };
   }
 
   Map<String, Map<String, dynamic>> _getPayloadRecords(dynamic payload) {

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.0.0-dev.2';
+const version = '1.0.0-dev.3';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: realtime_client
 description: Listens to changes in a PostgreSQL Database and via websockets. This is for usage with Supabase Realtime server.
-version: 1.0.0-dev.2
+version: 1.0.0-dev.3
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/realtime-dart'
 


### PR DESCRIPTION
realtime payload coming in as old format did not go through the payload enrichment, but this PR fixes that. 

fixes https://github.com/supabase-community/supabase-flutter/issues/215