### PR TITLE
realtime: with new supabase the payload is directly returned

### DIFF
--- a/lib/src/realtime_channel.dart
+++ b/lib/src/realtime_channel.dart
@@ -605,7 +605,7 @@ class RealtimeChannel {
   }
 
   Map<String, dynamic> _getEnrichedPayload(dynamic payload) {
-    final postgresChanges = payload['data'];
+    final postgresChanges = payload['data'] ?? payload;
     final schema = postgresChanges['schema'];
     final table = postgresChanges['table'];
     final commitTimestamp = postgresChanges['commit_timestamp'];


### PR DESCRIPTION
otherwise it throws:
```
---------- ERROR ----------
flutter: [2022-09-23 14:36:48.222282 | Catcher | INFO] NoSuchMethodError: The method '[]' was called on null.
```
for ```final schema = postgresChanges['schema'];```

using local supabase (started this morning) on macos.

(the branch fix/backward_compatibility has the same issue)