### PR TITLE
fix: sends null for access_token when not signed in

### DIFF
--- a/lib/src/realtime_client.dart
+++ b/lib/src/realtime_client.dart
@@ -331,7 +331,7 @@ class RealtimeClient {
         channel.updateJoinPayload({'user_token': token});
       }
       if (channel.joinedOnce && channel.isJoined) {
-        channel.push(ChannelEvents.accessToken, {'access_token': token ?? ''});
+        channel.push(ChannelEvents.accessToken, {'access_token': token});
       }
     }
   }


### PR DESCRIPTION
`null` should be sent as the `access_token` value when the user is not signed into the app. Currently, an empty string is being sent, which is causing invalid access_token issue. 

Related JS SDK code [here](https://github.com/supabase/realtime-js/blob/rc/src/RealtimeClient.ts#L379)

related https://github.com/supabase-community/supabase-flutter/issues/225