### PR TITLE
fix: allow null access token to be sent to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.15+1]
+
+- fix: allow null access token to be passed
+
 ## [0.1.15]
 
 - fix: use toString() instead of type cast error response

--- a/lib/src/realtime_client.dart
+++ b/lib/src/realtime_client.dart
@@ -312,7 +312,7 @@ class RealtimeClient {
         channel.updateJoinPayload({'user_token': token});
       }
       if (channel.joinedOnce && channel.isJoined()) {
-        channel.push(ChannelEvents.accessToken, {'access_token': token ?? ''});
+        channel.push(ChannelEvents.accessToken, {'access_token': token});
       }
     }
   }

--- a/lib/src/realtime_subscription.dart
+++ b/lib/src/realtime_subscription.dart
@@ -115,7 +115,7 @@ class RealtimeSubscription {
 
   Push push(
     ChannelEvents event,
-    Map<String, String> payload, {
+    Map<String, String?> payload, {
     Duration? timeout,
   }) {
     if (!joinedOnce) {

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '0.1.15';
+const version = '0.1.15+1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: realtime_client
 description: Listens to changes in a PostgreSQL Database and via websockets. This is for usage with Supabase Realtime server.
-version: 0.1.15
+version: 0.1.15+1
 homepage: "https://supabase.io"
 repository: "https://github.com/supabase/realtime-dart"
 


### PR DESCRIPTION
Fixes the bug where sending empty access token closes the connection. 